### PR TITLE
better panic tests

### DIFF
--- a/src/mathx/float/float_test.go
+++ b/src/mathx/float/float_test.go
@@ -188,7 +188,7 @@ func TestFloatDivZero(t *testing.T) {
 	x := NewFloat(10.0)
 	y := NewFloat(0.0)
 	defer func() {
-		if r := recover(); r != nil {
+		if r := recover(); r == "division by zero is undefined\n" {
 			fmt.Printf("Panicking because %v\n", r)
 			fmt.Print("TestFloatDivZero recovers from panic\n")
 		} else {
@@ -237,7 +237,7 @@ func TestFloatSqrt(t *testing.T) {
 func TestFloatSqrtNeg(t *testing.T) {
 	x := NewFloat(-10.0)
 	defer func() {
-		if r := recover(); r != nil {
+		if r := recover(); r == "square root of a negative number is undefined\n" {
 			fmt.Printf("Panicking because %v\n", r)
 			fmt.Print("TestFloatSqrtNeg recovers from panic\n")
 		} else {


### PR DESCRIPTION
I fixed the divide by zero test and the square root of negative number test, so that the defer checks for the correct error message from the panic rather than any error message.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/swenson/gomath/pull/4%23issuecomment-66513846%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/swenson/gomath/pull/4%23issuecomment-66513846%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222014-12-10T20%3A00%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/33404%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/swenson%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/swenson/gomath/pull/4#issuecomment-66513846'>General Comment</a></b>
- <a href='https://github.com/swenson'><img border=0 src='https://avatars.githubusercontent.com/u/33404?v=3' height=16 width=16'></a> LGTM

<a href='https://www.codereviewhub.com/swenson/gomath/pull/4?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/swenson/gomath/pull/4?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/swenson/gomath/pull/4'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
